### PR TITLE
Handle EU integrations in exports route

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ var MixpanelExport = (function () {
   };
 
   MixpanelExport.prototype._buildAPIStub = function (method) {
-    var apiStub = (method === 'export') ? 'https://data.mixpanel.com/api/2.0/' : `https://${this.eu ? 'eu.' : ''}mixpanel.com/api/2.0/`;
+    var apiStub = (method === 'export') ? `https://data${this.eu ? '-eu' : ''}.mixpanel.com/api/2.0/` : `https://${this.eu ? 'eu.' : ''}mixpanel.com/api/2.0/`;
     apiStub += (typeof method.join === 'function') ? method.join('/') : method;
     apiStub += '/?';
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@madkudu/node-mixpanel-export",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A lightweight SDK for the Mixpanel export API",
   "keywords": [
     "mixpanel",

--- a/test/index.js
+++ b/test/index.js
@@ -8,6 +8,7 @@ var panel = new MixpanelExport({
   api_secret: process.env.API_SECRET
 });
 
+// eslint-disable-next-line
 describe('node-mixpanel-export', function(){
 
   it('should expose the Mixpanel API methods', function () {
@@ -16,20 +17,35 @@ describe('node-mixpanel-export', function(){
     expect(panel).to.have.a.property('engage');
   });
   describe('_buildAPIStub', function () {
-    it('should return mixpanel.com for non-EU integrations', function () {
+    it('should return mixpanel.com for engage and Anon-EU integrations', function () {
       var panelNonEu = new MixpanelExport({
         api_secret: process.env.API_SECRET,
       });
       var url = panelNonEu._buildAPIStub('engage');
       expect(url).to.equal('https://mixpanel.com/api/2.0/engage/?');
     });
-    it('should return eu.mixpanel.com for EU integrations', function () {
+    it('should return eu.mixpanel.com for engage and EU integrations', function () {
       var panelEu = new MixpanelExport({
         api_secret: process.env.API_SECRET,
         eu: true
       });
       var url = panelEu._buildAPIStub('engage');
       expect(url).to.equal('https://eu.mixpanel.com/api/2.0/engage/?');
+    });
+    it('should return data.mixpanel.com for export and non-EU integrations', function () {
+      var panelNonEu = new MixpanelExport({
+        api_secret: process.env.API_SECRET,
+      });
+      var url = panelNonEu._buildAPIStub('export');
+      expect(url).to.equal('https://data.mixpanel.com/api/2.0/export/?');
+    });
+    it('should return data-eu.mixpanel.com for export and EU integrations', function () {
+      var panelEu = new MixpanelExport({
+        api_secret: process.env.API_SECRET,
+        eu: true
+      });
+      var url = panelEu._buildAPIStub('export');
+      expect(url).to.equal('https://data-eu.mixpanel.com/api/2.0/export/?');
     });
   });
 });


### PR DESCRIPTION
Follow-up to https://github.com/MadKudu/node-mixpanel-export/pull/6
data.mixpanel.com needs to be prefixed with ".eu" too for EU integrations