### PR TITLE
Fix/Support service accounts auth method for new tenants

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,5 +1,17 @@
 export type ClientOptions = {
+  /**
+   * Mixpanel [Project Secret](https://developer.mixpanel.com/reference/project-secret)
+   *
+   * **Warning**: This authentication method is in the process of being deprecated, Mixpanel claims
+   * that it will remain active for legacy customers indefinitely.
+   */
   apiSecret: string;
+  /**
+   * Mixpanel [Service Account](https://developer.mixpanel.com/reference/service-accounts)
+   *
+   * Currently recommended authentication method. Uses the format `<serviceaccount_username>:<serviceaccount_secret>`
+   */
+  account?: string;
   eu?: boolean;
 };
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -5,7 +5,7 @@ export type ClientOptions = {
    * **Warning**: This authentication method is in the process of being deprecated, Mixpanel claims
    * that it will remain active for legacy customers indefinitely.
    */
-  apiSecret: string;
+  apiSecret?: string;
   /**
    * Mixpanel [Service Account](https://developer.mixpanel.com/reference/service-accounts)
    *

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@madkudu/node-mixpanel-export",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.7",
@@ -575,11 +575,11 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
-      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
       "dependencies": {
-        "follow-redirects": "^1.15.4",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -1224,9 +1224,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@madkudu/node-mixpanel-export",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "A lightweight SDK for the Mixpanel export API",
   "keywords": [
     "mixpanel",


### PR DESCRIPTION
## Change Ticket [Required]

[5809 - Tabnine - Mixpanel connection error](https://app.asana.com/0/1202548546867610/1207583152807461/f)

Mixpanel [Project Secrets](https://developer.mixpanel.com/reference/project-secret) are _"in the process"_ of being deprecated for **new** customers, in favor of other methods including the newly recommended [Service Accounts](https://developer.mixpanel.com/reference/service-accounts). 

> _This authentication method is in the process of being deprecated. Please use Service Accounts instead. **We will continue to support Project Secret authentication for legacy customers indefinitely** so you aren't at risk of your existing scripts breaking, but we highly recommend migrating to Service Accounts for any subsequent usage._

This PR is intended to support both methods.

Afterwards, we can update the UI on `addax` and if there is any schema validation on `bongo` and `argo`.

## Add labels

- [ ] If this change contains changes to the infrastructure, add the _infrastructure_ label
- [ ] If this change contains access changes to the infrastructure, add the _access_ label
- [ ] If you're bypassing reviews for an emergency (admin only), add the _hotfix_ label
