### PR TITLE
fix service account support by prompting user to fill project id

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -7,11 +7,27 @@ export type ClientOptions = {
    */
   apiSecret?: string;
   /**
-   * Mixpanel [Service Account](https://developer.mixpanel.com/reference/service-accounts)
+   * Mixpanel [Service Account](https://developer.mixpanel.com/reference/service-accounts) username
    *
    * Currently recommended authentication method. Uses the format `<serviceaccount_username>:<serviceaccount_secret>`
    */
-  account?: string;
+  accountUsername?: string;
+  /**
+   * Mixpanel [Service Account](https://developer.mixpanel.com/reference/service-accounts) secret
+   *
+   * Currently recommended authentication method. Uses the format `<serviceaccount_username>:<serviceaccount_secret>`
+   */
+  accountSecret?: string;
+  /**
+   * If using Mixpanel [Service Account](https://developer.mixpanel.com/reference/service-accounts) auth method,
+   * this should be set to the Mixpanel project ID usually found in the project URL: `mixpanel.com/project/<project_id>`.
+   *
+   * Usually looks like a number.
+   */
+  projectId?: string;
+  /**
+   * If true, uses the EU Mixpanel API endpoint
+   */
   eu?: boolean;
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@madkudu/node-mixpanel-export",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@madkudu/node-mixpanel-export",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.7",


### PR DESCRIPTION
## Change Ticket [Required]

[5809 - Tabnine - Mixpanel connection error](https://app.asana.com/0/1202548546867610/1207583152807461/f)

Actually we need three fields in order to properly support service accounts. Project ID also becomes required if using that auth method.

This should mimic the hereby Postman request: https://madkudu.postman.co/workspace/MadKudu~22008ea4-9949-4b3b-834b-46dac3da3c40/request/21813793-5825ee58-7da5-4089-a07e-e14d79b4d3a7?action=share&source=copy-link&creator=21813793&ctx=documentation

## Add labels

- [ ] If this change contains changes to the infrastructure, add the _infrastructure_ label
- [ ] If this change contains access changes to the infrastructure, add the _access_ label
- [ ] If you're bypassing reviews for an emergency (admin only), add the _hotfix_ label
