### PR TITLE
Add support for 'where' filter for Mixpanel requests

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -14,11 +14,14 @@ export default class MixpanelClient {
   projectId?: string;
   /** If true, uses the EU Mixpanel API endpoint */
   eu?: boolean;
+  /** Optional filter for Mixpanel events using segmentation expressions syntax */
+  where?: string;
 
   constructor(opts: ClientOptions) {
     if (opts.apiSecret) {
       this.apiSecret = opts.apiSecret;
       this.eu = opts.eu;
+      this.where = opts.where;
       return;
     }
     if (opts.accountUsername && opts.accountSecret && opts.projectId) {
@@ -26,6 +29,7 @@ export default class MixpanelClient {
       this.accountSecret = opts.accountSecret;
       this.projectId = opts.projectId;
       this.eu = opts.eu;
+      this.where = opts.where;
       return;
     }
     throw new Error('Invalid Mixpanel client options');
@@ -60,6 +64,7 @@ export default class MixpanelClient {
 
   _getAuth(): AxiosRequestConfig {
     const isUsingServiceAccount = this.accountUsername && this.accountSecret;
+    const hasFilter = this.where && this.where.length > 0;
     const secret = isUsingServiceAccount
       ? `${this.accountUsername}:${this.accountSecret}`
       : this.apiSecret;
@@ -68,9 +73,11 @@ export default class MixpanelClient {
       headers: {
         Authorization: `Basic ${Buffer.from(secret).toString('base64')}`,
       },
+      params: {},
     };
 
-    if (isUsingServiceAccount) config.params = { project_id: this.projectId };
+    if (isUsingServiceAccount) config.params.project_id = this.projectId;
+    if (hasFilter) config.params.where = this.where;
 
     return config;
   }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -29,6 +29,11 @@ export type ClientOptions = {
    * If true, uses the EU Mixpanel API endpoint
    */
   eu?: boolean;
+  /**
+   * Optional filter for Mixpanel events using [segmentation expressions](https://developer.mixpanel.com/reference/segmentation-expressions)
+   * syntax.
+   */
+  where?: string;
 };
 
 export type EngageResult = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@madkudu/node-mixpanel-export",
-  "version": "1.1.5",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@madkudu/node-mixpanel-export",
-      "version": "1.1.5",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@madkudu/node-mixpanel-export",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A lightweight SDK for the Mixpanel export API",
   "keywords": [
     "mixpanel",


### PR DESCRIPTION
# PR

## Change Ticket [Required]

[5809 - Tab9 - Mixpanel connector down for 3 days](https://app.asana.com/0/1202548546867610/1207690991735558/f)

This is one of the needed backend parts in order to fix the issue. The frontend part https://github.com/MadKudu/addax/pull/2666 is already released.

Once released and published on `npm`, the last part should be updating `@madkudu/connectors` by bumping dependency and making couple edits.

## Add labels

- [ ] If this change contains changes to the infrastructure, add the _infrastructure_ label
- [ ] If this change contains access changes to the infrastructure, add the _access_ label
- [ ] If you're bypassing reviews for an emergency (admin only), add the _hotfix_ label
